### PR TITLE
Fixing issue with casing of keyword.

### DIFF
--- a/functions/router/router.js
+++ b/functions/router/router.js
@@ -20,7 +20,7 @@ exports.handler = function (context, event, callback) {
   }
 
   function getWebhook(keyword) {
-    if (keywords.has(keyword.toLowerCase())) return keywords.get(keyword);
+    if (keywords.has(keyword.toLowerCase())) return keywords.get(keyword.toLowerCase());
     return keywords.get('default');
   }
 


### PR DESCRIPTION
Fixing issue with casing of keyword. The map is checked for a lowercase version of the keyword, but value is returned from function as original casing, which can a null webhook to be stored in the session.  

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
